### PR TITLE
fix: preserve unary minus for a negative numeric

### DIFF
--- a/src/c/jsonpath_gram.c
+++ b/src/c/jsonpath_gram.c
@@ -2887,7 +2887,7 @@ makeItemUnary(JsonPathItemType type, JsonPathParseItem *a)
 	if (type == jpiMinus && a->type == jpiNumeric && !a->next)
 	{
 		v = makeItemType(jpiNumeric);
-		v->value.numeric = a->value.numeric;
+		v->value.numeric = -a->value.numeric;
 		return v;
 	}
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -32,6 +32,14 @@ const testVectors = [
         '- $.x',
         '{"expr":[{"type":"-unary","arg":[{"type":"$"},{"type":".key","value":"x"}]}],"lax":true}'
     ],
+    [
+        '+ 1',
+        '{"expr":[{"type":"numeric","value":1}],"lax":true}'
+    ],
+    [
+        '- 1',
+        '{"expr":[{"type":"numeric","value":-1}],"lax":true}'
+    ],
 ];
 
 // Test default export


### PR DESCRIPTION
Hello there and thank you for your work! 

Currently the AST strips away the unary minus so a numeric value `-1` becomes `1`. This PR addresses this small issue.